### PR TITLE
feat: remove secret deployment in charts

### DIFF
--- a/word-service/containers/helm/chart/templates/deployment.yaml
+++ b/word-service/containers/helm/chart/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "word-service.fullname" . }}-secret
-                  key: database_password
+                  name: postgres-postgresql
+                  key: postgres-password
             - name: DATABASE_PORT
               valueFrom:
                 configMapKeyRef:

--- a/word-service/containers/helm/chart/templates/secret.yaml
+++ b/word-service/containers/helm/chart/templates/secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "word-service.fullname" . }}-secret
-type: Opaque
-data:
-    database_password: {{ .Values.config.database_password | b64enc | quote }}


### PR DESCRIPTION
Removed the secrets from the word-service chart to add them as dependencies because they are deployed by the database