### PR TITLE
fix: postgres secret ref hardcoded

### DIFF
--- a/frontend/containers/helm/chart/Chart.yaml
+++ b/frontend/containers/helm/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.5"
+appVersion: "v0.0.8"

--- a/word-service/containers/helm/chart/Chart.yaml
+++ b/word-service/containers/helm/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 'v0.0.5'
+appVersion: 'v0.0.8'

--- a/word-service/containers/helm/chart/templates/configmap.yaml
+++ b/word-service/containers/helm/chart/templates/configmap.yaml
@@ -5,7 +5,6 @@ metadata:
 data:
   database_name: {{ .Values.config.database_name | quote }}
   database_username: {{ .Values.config.database_username | quote }}
-  database_password: {{ .Values.config.database_password | quote }}
   database_port: {{ .Values.config.database_port | quote }}
   database_host: {{ .Values.config.database_host | quote }}
   database_dialect: {{ .Values.config.database_dialect | quote }}

--- a/word-service/containers/helm/chart/templates/deployment.yaml
+++ b/word-service/containers/helm/chart/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-postgresql
-                  key: postgres-password
+                  name: {{.Values.config.database_password.secretName}}
+                  key: {{.Values.config.database_password.secretKey}}
             - name: DATABASE_PORT
               valueFrom:
                 configMapKeyRef:

--- a/word-service/containers/helm/chart/values.yaml
+++ b/word-service/containers/helm/chart/values.yaml
@@ -17,7 +17,9 @@ fullnameOverride: ''
 config:
   database_name: 'word'
   database_username: 'postgres'
-  database_password: 'postgres'
+  database_password:
+    secretName: 'postgres-postgresql'
+    secretKey: 'postgres-password'
   database_port: 5432
   database_host: 'postgres-postgresql'
   database_dialect: 'postgres'


### PR DESCRIPTION
The value of the secret from which the backend took the database password was hardcoded and the set value was in clear in cm