### PR TITLE
fix: argocd config is not modulable

### DIFF
--- a/infrastructure/helm/argo-cd-config/prod.values.yaml
+++ b/infrastructure/helm/argo-cd-config/prod.values.yaml
@@ -32,8 +32,8 @@ applications:
         extraParameters:
           config.database_name: word1
           config.service_name: word-1
-          ingress.hosts[0].host: word-1.192.168.10.10.sslip.io
-          ingress.tls[0].hosts[0]: word-1.192.168.10.10.sslip.io
+          ingress.hosts[0].host: word-1.${domain}
+          ingress.tls[0].hosts[0]: word-1.${domain}
           ingress.tls[0].secretName: word-1-tls
     destination:
       server: https://kubernetes.default.svc
@@ -52,8 +52,8 @@ applications:
         extraParameters:
           config.database_name: word2
           config.service_name: word-2
-          ingress.hosts[0].host: word-2.192.168.10.10.sslip.io
-          ingress.tls[0].hosts[0]: word-2.192.168.10.10.sslip.io
+          ingress.hosts[0].host: word-2.${domain}
+          ingress.tls[0].hosts[0]: word-2.${domain}
           ingress.tls[0].secretName: word-2-tls
     destination:
       server: https://kubernetes.default.svc
@@ -72,8 +72,8 @@ applications:
         extraParameters:
           config.database_name: word3
           config.service_name: word-3
-          ingress.hosts[0].host: word-3.192.168.10.10.sslip.io
-          ingress.tls[0].hosts[0]: word-3.192.168.10.10.sslip.io
+          ingress.hosts[0].host: word-3.${domain}
+          ingress.tls[0].hosts[0]: word-3.${domain}
           ingress.tls[0].secretName: word-3-tls
     destination:
       server: https://kubernetes.default.svc
@@ -90,7 +90,10 @@ applications:
         valueFiles:
           - ../prod.values.yaml
         extraParameters:
-          config.services_url: "https://word-1.192.168.10.10.sslip.io;https://word-2.192.168.10.10.sslip.io;https://word-3.192.168.10.10.sslip.io"
+          config.services_url: "https://word-1.${domain};https://word-2.${domain};https://word-3.${domain}"
+          ingress.hosts[0].host: www.${domain}
+          ingress.tls[0].hosts[0]: www.${domain}
+          ingress.tls[0].secretName: frontend-tls
     destination:
       server: https://kubernetes.default.svc
       namespace: words

--- a/infrastructure/terraform/prod/deployment/config.tf
+++ b/infrastructure/terraform/prod/deployment/config.tf
@@ -12,8 +12,10 @@ resource "helm_release" "argocd-config" {
   name      = "argocd-config"
   namespace = data.kubernetes_namespace_v1.argocd.metadata[0].name
 
-  chart  = "../../../helm/argo-cd-config/chart"
-  values = ["${file("../../../helm/argo-cd-config/prod.values.yaml")}"]
+  chart = "../../../helm/argo-cd-config/chart"
+  values = [templatefile("../../../helm/argo-cd-config/prod.values.yaml", {
+    domain = var.domain
+  })]
 
   set_sensitive {
     name  = "repositories.gitops-demo.ssh.privateKey"


### PR DESCRIPTION
The argo-config helm chart had hardcoded values for the ingress